### PR TITLE
fix: fix PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 - [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`refactor:`)
 - [ ] `README.md` updated
-- [ ] [`Ionos Cloud`](/docs/ionoscloud.md) doc updated
+- [ ] [`Ionos Cloud`](https://github.com/ionos-cloud/terraformer/blob/add-remaining-ionoscloud-resources/docs/ionoscloud.md) doc updated
 - [ ] [`Ionos Cloud Terraformer`](https://github.com/ionos-cloud/terraformer-documentation) doc updated - for this one please create a separate PR on the doc repo 
 - [ ] Changelog updated and version incremented (label: upcoming release)
 - [ ] Github Issue linked if any


### PR DESCRIPTION
## What does this fix or implement?

Fix PR template by providing a valid link for `Ionos Cloud` documentation reference.

<!-- Enter details of the change here. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`refactor:`)
- [ ] `README.md` updated
- [ ] [`Ionos Cloud`](/docs/ionoscloud.md) doc updated
- [ ] [`Ionos Cloud Terraformer`](https://github.com/ionos-cloud/terraformer-documentation) doc updated - for this one please create a separate PR on the doc repo 
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated