### PR TITLE
fix: use proper depth for API calls

### DIFF
--- a/providers/ionoscloud/kubernetes_node_pool.go
+++ b/providers/ionoscloud/kubernetes_node_pool.go
@@ -17,7 +17,7 @@ func (g *KubernetesNodePoolGenerator) InitResources() error {
 	cloudAPIClient := client.CloudAPIClient
 	resourceType := "ionoscloud_k8s_node_pool"
 
-	kubernetesClusters, _, err := cloudAPIClient.KubernetesApi.K8sGet(context.TODO()).Depth(1).Execute()
+	kubernetesClusters, _, err := cloudAPIClient.KubernetesApi.K8sGet(context.TODO()).Execute()
 	if err != nil {
 		return err
 	}

--- a/providers/ionoscloud/nic.go
+++ b/providers/ionoscloud/nic.go
@@ -20,7 +20,7 @@ func (g *NicGenerator) InitResources() error {
 		return err
 	}
 	for _, datacenter := range datacenters {
-		servers, _, err := cloudAPIClient.ServersApi.DatacentersServersGet(context.TODO(), *datacenter.Id).Depth(1).Execute()
+		servers, _, err := cloudAPIClient.ServersApi.DatacentersServersGet(context.TODO(), *datacenter.Id).Execute()
 		if err != nil {
 			return err
 		}
@@ -31,7 +31,7 @@ func (g *NicGenerator) InitResources() error {
 			continue
 		}
 		for _, server := range *servers.Items {
-			nics, _, err := cloudAPIClient.NetworkInterfacesApi.DatacentersServersNicsGet(context.TODO(), *datacenter.Id, *server.Id).Depth(2).Execute()
+			nics, _, err := cloudAPIClient.NetworkInterfacesApi.DatacentersServersNicsGet(context.TODO(), *datacenter.Id, *server.Id).Depth(1).Execute()
 			if err != nil {
 				return err
 			}

--- a/providers/ionoscloud/volume.go
+++ b/providers/ionoscloud/volume.go
@@ -31,7 +31,7 @@ func (g *VolumeGenerator) InitResources() error {
 			continue
 		}
 		for _, server := range *servers.Items {
-			volumes, _, err := cloudAPIClient.ServersApi.DatacentersServersVolumesGet(context.TODO(), *datacenter.Id, *server.Id).Depth(2).Execute()
+			volumes, _, err := cloudAPIClient.ServersApi.DatacentersServersVolumesGet(context.TODO(), *datacenter.Id, *server.Id).Depth(1).Execute()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## What does this fix or implement?

For some API calls we used a bigger depth that had no impact on the functionality, so I modified the values for the required calls.

<!-- Enter details of the change here. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`refactor:`)
- [ ] `README.md` updated
- [ ] [`Ionos Cloud`](https://github.com/ionos-cloud/terraformer/blob/add-remaining-ionoscloud-resources/docs/ionoscloud.md) doc updated
- [ ] [`Ionos Cloud Terraformer`](https://github.com/ionos-cloud/terraformer-documentation) doc updated - for this one please create a separate PR on the doc repo 
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [x] Jira task updated