### PR TITLE
feat: add support for CUBE and VCPU servers

### DIFF
--- a/providers/ionoscloud/server.go
+++ b/providers/ionoscloud/server.go
@@ -48,10 +48,18 @@ func (g *ServerGenerator) InitResources() error {
 				continue
 			}
 
+			var resourceType string
+
+			resourceType = getServerResourceType(*server.Properties.Type)
+			if resourceType == "" {
+				log.Printf("[WARNING] unknown server type: %v for server with ID: %v, skipping this server", *server.Properties.Type, *server.Id)
+				continue
+			}
+
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				*server.Id,
 				*server.Properties.Name+"-"+*server.Id,
-				"ionoscloud_server",
+				resourceType,
 				helpers.Ionos,
 				map[string]string{helpers.DcID: *datacenter.Id},
 				[]string{},
@@ -86,4 +94,17 @@ func isServerValid(server ionoscloud.Server, datacenterID string) bool {
 	}
 
 	return true
+}
+
+func getServerResourceType(serverType string) string {
+	resourceType := ""
+	switch serverType {
+	case "ENTERPRISE":
+		resourceType = "ionoscloud_server"
+	case "CUBE":
+		resourceType = "ionoscloud_cube_server"
+	case "VCPU":
+		resourceType = "ionoscloud_vcpu_server"
+	}
+	return resourceType
 }


### PR DESCRIPTION
## What does this fix or implement?

Add support for `CUBE` and `VCPU` servers by checking the type of the retrieved server inside the `server.go` file.

The servers will be imported using:
```
./terraformer-ionoscloud import ionoscloud --resources="server"
```
Inside the generated directory, we will see three different files for all server types: `cube_server.tf`, `vcpu_server.tf` and `server.tf`


<!-- Enter details of the change here. -->

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`refactor:`)
- [ ] `README.md` updated
- [ ] [`Ionos Cloud`](https://github.com/ionos-cloud/terraformer/blob/add-remaining-ionoscloud-resources/docs/ionoscloud.md) doc updated
- [ ] [`Ionos Cloud Terraformer`](https://github.com/ionos-cloud/terraformer-documentation) doc updated - for this one please create a separate PR on the doc repo 
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any
- [ ] Jira task updated